### PR TITLE
Remove base url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@
 # Site Settings
 title: Maria Herrera CV
 url: 'https://mherrera.dev'
-baseurl: '/cv' #change it according to your repository name
+baseurl: '/' #change it according to your repository name
 description: A beautiful Jekyll theme for creating resume
 # Style will be applied only after restarting the build or serve. Just choose one of the options.
 theme_skin: berry # blue turquoise green berry orange ceramic


### PR DESCRIPTION
not needed as this repo is the base page for the URL

The webpage is using the '/cv' information to try to load the assets (i.e. CSS and JavaScript files). But because the GitHub Page is set up on the root of the URL (i.e. with no '/cv') the JS and CSS files are not being found.

i.e. mherrera.dev/cv/assets/style.css  -> this doesn't load a file, as the URL should be mherrera.dev/assets/style.css